### PR TITLE
Dev merge: MathParser working; Expressions print better

### DIFF
--- a/monarithmos/ArithmeticTree.cs
+++ b/monarithmos/ArithmeticTree.cs
@@ -99,7 +99,7 @@ class Ratio : BinOp
     public override string AsString()
     {
         string ret = "";
-        if(A is Number)
+        if(A is Number || A is Product)
             ret += A.AsString();
         else
             ret += A.AsInParentheses();
@@ -141,14 +141,14 @@ class Product : BinOp
     public override string AsString()
     {
         string ret = "";
-        if(A is Number)
+        if(A is Number || A is Product || A is Power)
             ret += A.AsString();
         else
             ret += A.AsInParentheses();
         
         ret += "*";
         
-        if(B is Number && B.GetValue() >= 0)
+        if((B is Number || B is Product || B is Power || B is Ratio) && B.GetValue() >= 0)
             ret += B.AsString();
         else
             ret += B.AsInParentheses();
@@ -175,14 +175,14 @@ class Sum : BinOp
     public override string AsString()
     {
         string ret = "";
-        if(A is Number)
+        if(A is Number || A is Sum || A is Difference)
             ret += A.AsString();
         else
             ret += A.AsInParentheses();
         
         ret += " + "; // Addition operator
         
-        if(B is Number && B.GetValue() >= 0)
+        if((B is Number || B is Sum || B is Difference) && B.GetValue() >= 0)
             ret += B.AsString();
         else
             ret += B.AsInParentheses();
@@ -211,14 +211,14 @@ class Difference : BinOp
     public override string AsString()
     {
         string ret = "";
-        if(A is Number)
+        if(A is Number || A is Sum || A is Difference || A is Power)
             ret += A.AsString();
         else
             ret += A.AsInParentheses();
         
         ret += " - "; // Subtraction operator
         
-        if(B is Number && B.GetValue() >= 0)
+        if((B is Number || B is Sum || B is Difference || B is Power) && B.GetValue() >= 0)
             ret += B.AsString();
         else
             ret += B.AsInParentheses();

--- a/monarithmos/ParseMath.cs
+++ b/monarithmos/ParseMath.cs
@@ -1,0 +1,70 @@
+using System
+using AsithmeticTree.cs
+
+class MathParser
+{
+	private char cursor;
+	
+	private char readNext();
+	private void nextChar();
+	
+	private Expression? E();
+	private Expression? T();	
+	private Expression? F();
+	
+	private Expression? E()
+	{
+		Expression? ret = null;
+		Expression? tmp = null;
+		
+		ret = T();
+			
+		if(ret != null) 
+		{ // some would call this block  " E' " or " Edash ". It specifies what can follow a term (either sum/diff or nothing).
+			if(cursor == '+')
+			{
+				tmp = ret;
+				ret = new Sum(tmp, T());
+				nextChar();
+			}
+			else if (cursor == '-')
+			{
+				tmp = ret;
+				ret = new Difference(tmp, T());
+				nextChar();
+			}
+		}
+		
+		return ret;
+	}
+	
+	private Expression? T()
+	{
+		Expression? ret = null;
+		Expression? tmp = null;
+		
+		ret = F();
+		
+		if(ret != null)
+		{ // Somw would call thhis block " T' " or " Tdash ". It specifies what may follow a Factor (either multiply/divide or nothing)
+			if(cursor == '*')
+			{
+				tmp = ret;
+				ret = new Product(tmp, F());
+				nextChar();
+			}
+			else if (cursor == '/') 
+			{
+				tmp = ret;
+				ret = new Ratio(tmp, F());
+			}
+		}
+		
+		return ret;
+	}
+	
+	private Expression? F()
+	{
+		return null;
+	}
+}

--- a/monarithmos/ParseMath.cs
+++ b/monarithmos/ParseMath.cs
@@ -1,37 +1,94 @@
-using System
-using AsithmeticTree.cs
+using System;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ParseMath;
 
 class MathParser
 {
-	private char cursor;
+	private char cursor = ' ';
+	private string buffer = "";
+	private int count = 0;
+	private bool end = false;
+
+	static private bool IsDigit(char ch)
+	{
+		return (ch == '0') || (ch == '1') ||
+		       (ch == '2') || (ch == '3') ||
+		       (ch == '4') || (ch == '5') ||
+		       (ch == '6') || (ch == '7') ||
+		       (ch == '8') || (ch == '9');
+	}
+
+	private void nextChar()
+	{
+		if(count+1 < buffer.Length)
+		{
+			count++;
+			cursor = buffer[count];
+		}
+		else
+		{
+			end = true;
+		}
+
+		if (!end && cursor == ' ')
+			nextChar();
+	}
+
+	private void skip(int steps)
+	{
+		int tmp = count;
+		while(count+1 < buffer.Length && count < tmp+steps)
+		{
+			count++;
+		}
+	}
 	
-	private char readNext();
-	private void nextChar();
-	
-	private Expression? E();
-	private Expression? T();	
-	private Expression? F();
-	
+	public Expression? Parse(string buff)
+	{
+		buffer = buff;
+
+		Console.WriteLine("buffer.Length: " + buffer.Length.ToString());
+		
+		if (buffer.Length > 0)
+		{
+			buffer = buff;
+			cursor = buff[0];	
+
+			Console.WriteLine("Starting to parse string: " + buff);
+
+			return E();
+		}
+		else
+		{
+			return null;
+		}
+	} 
+
 	private Expression? E()
 	{
-		Expression? ret = null;
+		Expression? ret;
 		Expression? tmp = null;
 		
 		ret = T();
-			
-		if(ret != null) 
+		
+		while (!end && ret!=null && (cursor == '+' || cursor == '-'))
 		{ // some would call this block  " E' " or " Edash ". It specifies what can follow a term (either sum/diff or nothing).
 			if(cursor == '+')
 			{
-				tmp = ret;
-				ret = new Sum(tmp, T());
 				nextChar();
+				
+				tmp = ret;
+				ret = T();
+				if (ret!=null) ret = new Sum(tmp, ret);
 			}
-			else if (cursor == '-')
+			else
 			{
-				tmp = ret;
-				ret = new Difference(tmp, T());
 				nextChar();
+
+				tmp = ret;
+				ret = T();
+				if(ret != null) ret = new Difference(tmp, ret);
 			}
 		}
 		
@@ -45,26 +102,91 @@ class MathParser
 		
 		ret = F();
 		
-		if(ret != null)
-		{ // Somw would call thhis block " T' " or " Tdash ". It specifies what may follow a Factor (either multiply/divide or nothing)
+		while(!end && ret != null && (cursor == '*' || cursor == '/' || cursor == ':'))
+		{ // Some would call thhis block " T' " or " Tdash ". It specifies what may follow a Factor (either multiply/divide or nothing)
 			if(cursor == '*')
 			{
-				tmp = ret;
-				ret = new Product(tmp, F());
 				nextChar();
-			}
-			else if (cursor == '/') 
-			{
 				tmp = ret;
-				ret = new Ratio(tmp, F());
+				ret = F();
+				if(ret != null) ret = new Product(tmp, ret);
+			}
+
+			else 
+			{
+				nextChar();
+				tmp = ret;
+				ret = F();
+				if(ret != null) ret = new Ratio(tmp, ret);
 			}
 		}
 		
+		//ret = N();
+
 		return ret;
 	}
 	
 	private Expression? F()
 	{
-		return null;
+		Expression? ret = null;
+
+		if(cursor == '(')
+		{
+			nextChar();
+			ret = E();
+			if(ret != null)
+			{
+				if (cursor == ')')
+					nextChar();
+			}
+			else
+			{
+				ret = null;
+			}
+		}
+		
+		else if (IsDigit (cursor) || cursor == '-')
+		{
+			ret = N();
+		}
+
+		return ret;
+	}
+
+	private Expression? N()
+	{
+		bool gotNumber = false;
+		double num = 0;
+		int size = 0;
+
+		while (count + size < buffer.Length && (IsDigit(buffer[count+size]) || buffer[count+size] == '.'))
+		{
+			size++;
+			gotNumber = true;
+		}
+
+		Console.WriteLine("gotNumber:  " + gotNumber.ToString());
+		Console.WriteLine("size:       " + size.ToString());
+
+		if(gotNumber)
+		{
+
+			if(count + size >= buffer.Length) size = buffer.Length - count;
+
+			Console.WriteLine("Trying to parse into double: ");
+			num = double.Parse (buffer.Substring (count, size));
+
+			count += size-1;
+			nextChar();
+
+			Console.WriteLine("Updating cursor: ");
+			cursor = buffer[count];
+
+			return new Number(num);
+		}
+		else
+		{
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
# ParseMath.cs
It is now possible not only to print expressions as strings, but also, through the **MathParser class**, to **parse strings into expressions**. This class, with its functions for parsing expressions of specific precedence (E, T, F, and N), works like a **Recursive descent parser**, reads the string from left to right, with no backtracking, and builds the expression as a **Tree** (now binary tree, as I only have binary operations), which also works like an **Abstract Syntax Tree** (AST) for the mathematical language.
**This closes #2 .**

In the built tree, the root is the most external operation, or the last one to be solved; the leaves are numbers. Since the whole expression is branched off from the root, dealing with the expression meas dealing with the root: this applies to these recursive methods:
* string Expression.AsString (or ToString)
* double Expression.GetValue
* bool Expression.IsValid

That may be used in the future, for **expression simplification problems**, that require certain operations to remain unsolved (like roots, fractions and sines); e.g., 100 sqrt(20) / 10 -> 20 sqrt(5).  It may also be used in a calculator.

What certainly will be in the final product, at the very least, and which will need the MathParser, is the **fraction simplification exercise**; e.g., 6/144 = 1/24

# ArithmeticTree.cs
In this file, only the AsString methods changed, so that by default they only include parentheses actually necessary for clarity. I should add verbose printing as an option later.